### PR TITLE
Fix debug information

### DIFF
--- a/include/klee/Internal/Module/InstructionInfoTable.h
+++ b/include/klee/Internal/Module/InstructionInfoTable.h
@@ -26,7 +26,8 @@
 namespace llvm {
   class Function;
   class Instruction;
-  class Module; 
+  class Module;
+  class LLVMContext;
 }
 
 namespace klee {
@@ -36,18 +37,14 @@ namespace klee {
     unsigned id;
     const std::string &file;
     unsigned line;
+    unsigned column;
     unsigned assemblyLine;
 
   public:
-    InstructionInfo(unsigned _id,
-                    const std::string &_file,
-                    unsigned _line,
-                    unsigned _assemblyLine)
-      : id(_id), 
-        file(_file),
-        line(_line),
-        assemblyLine(_assemblyLine) {
-    }
+    InstructionInfo(unsigned _id, const std::string &_file, unsigned _line,
+                    unsigned _column, unsigned _assemblyLine)
+        : id(_id), file(_file), line(_line), column(_column),
+          assemblyLine(_assemblyLine) {}
   };
 
   class InstructionInfoTable {
@@ -60,12 +57,14 @@ namespace klee {
     std::string dummyString;
     InstructionInfo dummyInfo;
     unordered_map<const llvm::Instruction *, InstructionInfo> infos;
+    unordered_map<const llvm::Function *, InstructionInfo> functionInfos;
     std::set<const std::string *, ltstr> internedStrings;
 
   private:
     const std::string *internString(std::string s);
-    bool getInstructionDebugInfo(const llvm::Instruction *I,
-                                 const std::string *&File, unsigned &Line);
+    bool getInstructionDebugInfo(llvm::Instruction *I, const std::string *&File,
+                                 unsigned &Line, unsigned &Column,
+                                 llvm::LLVMContext &context);
 
   public:
     InstructionInfoTable(llvm::Module *m);

--- a/include/klee/Internal/Module/InstructionInfoTable.h
+++ b/include/klee/Internal/Module/InstructionInfoTable.h
@@ -14,6 +14,15 @@
 #include <string>
 #include <set>
 
+#include <ciso646>
+#ifdef _LIBCPP_VERSION
+#include <unordered_map>
+#define unordered_map std::unordered_map
+#else
+#include <tr1/unordered_map>
+#define unordered_map std::tr1::unordered_map
+#endif
+
 namespace llvm {
   class Function;
   class Instruction;
@@ -50,7 +59,7 @@ namespace klee {
 
     std::string dummyString;
     InstructionInfo dummyInfo;
-    std::map<const llvm::Instruction*, InstructionInfo> infos;
+    unordered_map<const llvm::Instruction *, InstructionInfo> infos;
     std::set<const std::string *, ltstr> internedStrings;
 
   private:

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1421,9 +1421,16 @@ Function* Executor::getTargetFunction(Value *calledVal, ExecutionState &state) {
   }
 }
 
-/// TODO remove?
 static bool isDebugIntrinsic(const Function *f, KModule *KM) {
-  return false;
+  if (!f->isIntrinsic())
+    return false;
+  switch (f->getIntrinsicID()){
+  case Intrinsic::dbg_value:
+  case Intrinsic::dbg_declare:
+    return true;
+  default:
+    return false;
+  }
 }
 
 static inline const llvm::fltSemantics * fpWidthToSemantics(unsigned width) {

--- a/lib/Module/Checks.cpp
+++ b/lib/Module/Checks.cpp
@@ -52,6 +52,8 @@ bool DivCheckPass::runOnModule(Module &M) {
                                           false,  /* sign doesn't matter */
                                           "int_cast_to_i64",
                                           &*i);
+            denominator->setDebugLoc(binOp->getDebugLoc());
+
             
             // Lazily bind the function to avoid always importing it.
             if (!divZeroCheckFunction) {
@@ -110,6 +112,7 @@ bool OvershiftCheckPass::runOnModule(Module &M) {
                                           false,  /* sign doesn't matter */
                                           "int_cast_to_i64",
                                           &*i);
+            shift->setDebugLoc(binOp->getDebugLoc());
             args.push_back(shift);
 
 

--- a/lib/Module/InstructionInfoTable.cpp
+++ b/lib/Module/InstructionInfoTable.cpp
@@ -166,8 +166,8 @@ unsigned InstructionInfoTable::getMaxID() const {
 
 const InstructionInfo &
 InstructionInfoTable::getInfo(const Instruction *inst) const {
-  std::map<const llvm::Instruction*, InstructionInfo>::const_iterator it = 
-    infos.find(inst);
+  unordered_map<const llvm::Instruction *, InstructionInfo>::const_iterator it =
+      infos.find(inst);
   if (it == infos.end())
     llvm::report_fatal_error("invalid instruction, not present in "
                              "initial module!");

--- a/lib/Module/InstructionInfoTable.cpp
+++ b/lib/Module/InstructionInfoTable.cpp
@@ -32,6 +32,7 @@
 #include "llvm/IR/DebugInfo.h"
 #else
 #include "llvm/DebugInfo.h"
+#include "llvm/Transforms/Utils/Local.h"
 #endif
 
 #include "llvm/Analysis/ValueTracking.h"
@@ -90,54 +91,127 @@ static std::string getDSPIPath(const DILocation &Loc) {
   }
 }
 
-bool InstructionInfoTable::getInstructionDebugInfo(const llvm::Instruction *I, 
+static std::string concatLocation(const std::string &dir,
+                                  const std::string &file) {
+  if (dir.empty() || file[0] == '/') {
+    return file;
+  } else if (*dir.rbegin() == '/') {
+    return dir + file;
+  } else {
+    return dir + "/" + file;
+  }
+}
+
+bool InstructionInfoTable::getInstructionDebugInfo(llvm::Instruction *I,
                                                    const std::string *&File,
-                                                   unsigned &Line) {
-  if (MDNode *N = I->getMetadata("dbg")) {
-    DILocation Loc(N);
-    File = internString(getDSPIPath(Loc));
-    Line = Loc.getLineNumber();
+                                                   unsigned &Line,
+                                                   unsigned &Column,
+                                                   LLVMContext &context) {
+  DbgDeclareInst *DDI = 0;
+  if (isa<AllocaInst>(I)) {
+    DDI = FindAllocaDbgDeclare(I);
+  } else if (isa<StoreInst>(I) || isa<LoadInst>(I)) {
+    // Check if the following instruction is a DbgDeclareIsnt
+    BasicBlock::iterator it(I);
+    ++it;
+    DDI = dyn_cast<DbgDeclareInst>(&*it);
+  }
+  if (DDI) {
+    // Get variable description meta data
+    DIVariable var_node(DDI->getVariable());
+    File = internString(var_node.getFile().getFilename());
+    Line = var_node.getLineNumber();
+    // Column information is not available, default it to 0
+    Column = 0;
     return true;
   }
 
-  return false;
+  const DebugLoc &loc = I->getDebugLoc();
+
+  // Check if we know anything about this code location
+  if (loc.isUnknown())
+    return false;
+
+  Line = loc.getLine();
+  Column = loc.getCol();
+
+  MDNode *scope = 0;
+  MDNode *inlinedAt = 0;
+  loc.getScopeAndInlinedAt(scope, inlinedAt, context);
+
+  assert(scope && "Scope invalid");
+
+  // Handle scope
+  DILocation scopeLoc(scope);
+  File = internString(getDSPIPath(scopeLoc));
+
+  if (inlinedAt) {
+    DILocation inlinedLoc(inlinedAt);
+    File = internString(getDSPIPath(inlinedLoc));
+  } else {
+
+    DILocation Loc(loc.getAsMDNode(context));
+    File = internString(getDSPIPath(Loc));
+  }
+  return true;
 }
 
-InstructionInfoTable::InstructionInfoTable(Module *m) 
-  : dummyString(""), dummyInfo(0, dummyString, 0, 0) {
+InstructionInfoTable::InstructionInfoTable(Module *m)
+    : dummyString(""), dummyInfo(0, dummyString, 0, 0, 0) {
   unsigned id = 0;
   std::map<const Instruction*, unsigned> lineTable;
   buildInstructionToLineMap(m, lineTable);
 
-  for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); 
-       fnIt != fn_ie; ++fnIt) {
-    Function *fn = &*fnIt;
+  llvm::DebugInfoFinder DbgFinder;
+  DbgFinder.processModule(*m);
 
-    // We want to ensure that as all instructions have source information, if
-    // available. Clang sometimes will not write out debug information on the
-    // initial instructions in a function (correspond to the formal parameters),
-    // so we first search forward to find the first instruction with debug info,
-    // if any.
-    const std::string *initialFile = &dummyString;
-    unsigned initialLine = 0;
-    for (inst_iterator it = inst_begin(fn), ie = inst_end(fn); it != ie; ++it) {
-      if (getInstructionDebugInfo(&*it, initialFile, initialLine))
-        break;
+  // process debug information of functions
+  for (DebugInfoFinder::iterator fIt = DbgFinder.subprogram_begin(),
+                                 fItE = DbgFinder.subprogram_end();
+       fIt != fItE; ++fIt) {
+    DISubprogram SubP(*fIt);
+    assert(SubP.Verify());
+    if (SubP.getFunction() == 0)
+      continue;
+
+    // skip if information already acquired.
+    // e.g. due to multiple includes of the same files
+    if (functionInfos.count(SubP.getFunction()))
+      continue;
+
+    unsigned assemblyLine = 0;
+    Function *f = SubP.getFunction();
+    if (!f->isDeclaration()) {
+      assemblyLine = lineTable[f->getEntryBlock().begin()];
     }
+    functionInfos.insert(std::make_pair(
+        SubP.getFunction(),
+        InstructionInfo(0, *internString(concatLocation(SubP.getDirectory(),
+                                                        SubP.getFilename())),
+                        SubP.getLineNumber(), 0, assemblyLine)));
+  }
 
-    const std::string *file = initialFile;
-    unsigned line = initialLine;
-    for (inst_iterator it = inst_begin(fn), ie = inst_end(fn); it != ie;
-        ++it) {
+  for (Module::iterator fnIt = m->begin(), fn_ie = m->end(); fnIt != fn_ie;
+       ++fnIt) {
+
+    const std::string *file = &dummyString;
+    unsigned line = 0;
+    unsigned column = 0;
+    for (inst_iterator it = inst_begin(fnIt), ie = inst_end(fnIt); it != ie;
+         ++it) {
       Instruction *instr = &*it;
       unsigned assemblyLine = lineTable[instr];
 
       // Update our source level debug information.
-      getInstructionDebugInfo(instr, file, line);
+      if (!getInstructionDebugInfo(instr, file, line, column,
+                                   m->getContext())) {
+        file = &dummyString;
+        line = 0;
+        column = 0;
+      }
 
-      infos.insert(std::make_pair(instr,
-                                  InstructionInfo(id++, *file, line,
-                                                  assemblyLine)));
+      infos.insert(std::make_pair(
+          instr, InstructionInfo(id++, *file, line, column, assemblyLine)));
     }
   }
 }
@@ -183,7 +257,14 @@ InstructionInfoTable::getFunctionInfo(const Function *f) const {
     // shared across all functions). I'd like to see if this matters in practice
     // and construct a test case for it if it does, though.
     return dummyInfo;
-  } else {
-    return getInfo(&*(f->begin()->begin()));
   }
+
+  // use debug information of the function if available
+  // otherwise return debug information of the first instruction of the function
+  const InstructionInfo &firstInst = getInfo(f->begin()->begin());
+  unordered_map<const llvm::Function *, InstructionInfo>::const_iterator it =
+      functionInfos.find(f);
+  if (it == functionInfos.end())
+    return firstInst;
+  return it->second;
 }

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -184,11 +184,6 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
 
       case Intrinsic::dbg_value:
       case Intrinsic::dbg_declare:
-        // Remove these regardless of lower intrinsics flag. This can
-        // be removed once IntrinsicLowering is fixed to not have bad
-        // caches.
-        ii->eraseFromParent();
-        dirty = true;
         break;
 
       case Intrinsic::trap: {

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -36,9 +36,10 @@
 
 #include "klee/Internal/Module/LLVMPassManager.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/raw_os_ostream.h"
+#include "llvm/Support/InstIterator.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/raw_os_ostream.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Scalar.h"
 
 #include <llvm/Transforms/Utils/Cloning.h>


### PR DESCRIPTION
@hanouchen As disccussed, here are the patches which should give you back the power of the debug instructions. Especially, have a look at https://github.com/hanouchen/klee/commit/cb0443d80dfd2cf34bba5d9ae6248fd2b4a8a7ec which gives you a detailled idea for iterating over the debug instructions. This way you should be able to extract most of the information. In case of any questions, let me know.